### PR TITLE
feat: add support for IE11

### DIFF
--- a/addon/modifiers/on.js
+++ b/addon/modifiers/on.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import addEventListener from '../utils/add-event-listener';
 
 export default Ember._setModifierManager(
   () => ({
@@ -20,7 +21,7 @@ export default Ember._setModifierManager(
       }
     ) {
       if (typeof eventName === 'string' && typeof callback === 'function')
-        element.addEventListener(eventName, callback, eventOptions);
+        addEventListener(element, eventName, callback, eventOptions);
 
       state.element = element;
       state.eventName = eventName;
@@ -42,7 +43,7 @@ export default Ember._setModifierManager(
         state.element.removeEventListener(state.eventName, state.callback);
 
       if (typeof eventName === 'string' && typeof callback === 'function')
-        state.element.addEventListener(eventName, callback, eventOptions);
+        addEventListener(state.element, eventName, callback, eventOptions);
 
       state.eventName = eventName;
       state.callback = callback;

--- a/addon/utils/add-event-listener.js
+++ b/addon/utils/add-event-listener.js
@@ -1,0 +1,74 @@
+/**
+ * Internet Explorer 11 does not support `once` and also does not support
+ * passing `eventOptions`. In some situations it then throws a weird script
+ * error, like:
+ *
+ * ```
+ * Could not complete the operation due to error 80020101
+ * ```
+ *
+ * This flag determines, whether `{ once: true }` and thus also event options in
+ * general are supported.
+ */
+export const SUPPORTS_EVENT_OPTIONS = (() => {
+  try {
+    const div = document.createElement('div');
+    let counter = 0;
+    div.addEventListener('click', () => counter++);
+
+    let event;
+    if (typeof Event === 'function') {
+      event = new Event('click');
+    } else {
+      event = document.createEvent('Event');
+      event.initEvent('click', true, true);
+    }
+
+    div.dispatchEvent(event);
+    div.dispatchEvent(event);
+
+    return counter === 1;
+  } catch (err) {
+    return false;
+  }
+})();
+
+/**
+ * Safely invokes `addEventListener` for IE11 and also polyfills the
+ * `{ once: true }` option. All other options are discarded for IE11.
+ *
+ * @param {Element} element
+ * @param {string} eventName
+ * @param {Function} callback
+ * @param {object} [eventOptions]
+ */
+export default function addEventListener(
+  element,
+  eventName,
+  callback,
+  eventOptions
+) {
+  if (SUPPORTS_EVENT_OPTIONS) {
+    element.addEventListener(eventName, callback, eventOptions);
+  } else if (eventOptions && eventOptions.once) {
+    addEventListenerOnce(element, eventName, callback);
+  } else {
+    element.addEventListener(eventName, callback);
+  }
+}
+
+/**
+ * Registers an event for an `element` that is called exactly once and then
+ * unregistered again. This is effectively a polyfill for `{ once: true }`.
+ *
+ * @param {Element} element
+ * @param {string} eventName
+ * @param {Function} callback
+ */
+export function addEventListenerOnce(element, eventName, callback) {
+  function listener() {
+    element.removeEventListener(eventName, listener);
+    callback();
+  }
+  element.addEventListener(eventName, listener);
+}


### PR DESCRIPTION
Internet Explorer 11 does not fully support `addEventListener`. The last argument, `eventOptions`, is ignored and sometimes throws as weird script error.
This also means that `{ once: true }` did not work in IE11.

This PR polyfills support for `{ once: true }` in IE11 and discards any other `eventOptions` to prevent script errors.