### PR TITLE
chore: Deprecate `(prevent-default)` helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
+    - env: EMBER_TRY_SCENARIO=ember-default-with-ember-event-helpers
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/README.md
+++ b/README.md
@@ -196,25 +196,31 @@ export default class UserListComponent extends Component {
 }
 ```
 
-### `preventDefault`
+### `preventDefault` / `stopPropagation` / `stopImmediatePropagation`
 
-This addon ships a `prevent-default` template helper, that you can use like
-this:
-
-```hbs
-<a href="/" {{on "click" (prevent-default this.someAction)}}>Click me</a>
-```
-
-```hbs
-<a href="/" {{on "click" this.someAction}} {{on "click" (prevent-default)}}>Click me</a>
-```
-
-This is effectively the same as calling `event.preventDefault()` in your event
-handler or using the [`{{action}}` modifier][action-event-propagation]
-like this:
+The old [`{{action}}` modifier][action-event-propagation] used to allow easily
+calling `event.preventDefault()` like so:
 
 ```hbs
 <a href="/" {{action this.someAction preventDefault=true}}>Click me</a>
 ```
 
 [action-event-propagation]: https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/action?anchor=action#event-propagation
+
+You also could easily call `event.stopPropagation()` to avoid bubbling like so:
+
+```hbs
+<a href="/" {{action this.someAction bubbles=false}}>Click me</a>
+```
+
+You can still do this using [`ember-event-helpers`][ember-event-helpers]:
+
+[ember-event-helpers]: https://github.com/buschtoens/ember-event-helpers
+
+```hbs
+<a href="/" {{on "click" (prevent-default this.someAction)}}>Click me</a>
+```
+
+```hbs
+<a href="/" {{on "click" (stop-propagation this.someAction)}}>Click me</a>
+```

--- a/addon/helpers/prevent-default.js
+++ b/addon/helpers/prevent-default.js
@@ -1,7 +1,17 @@
 import { helper } from '@ember/component/helper';
 import { assert } from '@ember/debug';
+import { deprecate } from '@ember/application/deprecations';
 
 export function preventDefault([handler]) {
+  deprecate(
+    '`(prevent-default)` has been moved to `ember-event-helpers`.',
+    false,
+    {
+      id: 'ember-on-modifier.prevent-default',
+      until: '1.0.0',
+      url: 'https://github.com/buschtoens/ember-event-helpers'
+    }
+  );
   assert(
     `Expected '${handler}' to be a function, if present.`,
     !handler || typeof handler === 'function'

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -93,6 +93,17 @@ module.exports = function() {
               '@ember/jquery': '^0.5.1'
             }
           }
+        },
+        {
+          name: 'ember-default-with-ember-event-helpers',
+          env: {
+            EMBER_EVENT_HELPERS_INSTALLED: true
+          },
+          npm: {
+            devDependencies: {
+              'ember-event-helpers': '^0.1.0'
+            }
+          }
         }
       ]
     };

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = {
 
   filterTree(tree) {
     if (this.hasEventHelpers) {
-      tree = new Funnel(tree, { exclude: [/helpers/] });
+      return new Funnel(tree, { exclude: [/helpers/] });
     }
 
     return tree;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,31 @@
 'use strict';
 
+const Funnel = require('broccoli-funnel');
+
 module.exports = {
-  name: require('./package').name
+  name: require('./package').name,
+
+  included(...args) {
+    this._super.included.apply(this, args);
+
+    this.hasEventHelpers = Boolean(
+      this.project.findAddonByName('ember-event-helpers')
+    );
+  },
+
+  treeForApp(...args) {
+    return this.filterTree(this._super.treeForApp.apply(this, args));
+  },
+
+  treeForAddon(...args) {
+    return this.filterTree(this._super.treeForAddon.apply(this, args));
+  },
+
+  filterTree(tree) {
+    if (this.hasEventHelpers) {
+      tree = new Funnel(tree, { exclude: [/helpers/] });
+    }
+
+    return tree;
+  }
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
+    "broccoli-funnel": "^2.0.2",
     "ember-cli-babel": "^7.7.3",
     "ember-modifier-manager-polyfill": "^1.0.3"
   },

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -20,7 +20,11 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
-    }
+    },
+
+    EMBER_EVENT_HELPERS_INSTALLED: Boolean(
+      process.env.EMBER_EVENT_HELPERS_INSTALLED
+    )
   };
 
   if (environment === 'development') {

--- a/tests/helpers/ember-event-helpers.js
+++ b/tests/helpers/ember-event-helpers.js
@@ -1,0 +1,11 @@
+import { test, skip } from 'qunit';
+import config from 'dummy/config/environment';
+
+export const { EMBER_EVENT_HELPERS_INSTALLED } = config;
+
+export const testIfEventHelpersInstalled = EMBER_EVENT_HELPERS_INSTALLED
+  ? test
+  : skip;
+export const skipIfEventHelpersInstalled = EMBER_EVENT_HELPERS_INSTALLED
+  ? skip
+  : test;

--- a/tests/integration/helpers/prevent-default-test.js
+++ b/tests/integration/helpers/prevent-default-test.js
@@ -1,7 +1,12 @@
-import { module, test } from 'qunit';
+import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import require from 'require';
+import {
+  testIfEventHelpersInstalled,
+  skipIfEventHelpersInstalled
+} from '../../helpers/ember-event-helpers';
 
 module('Integration | Helper | prevent-default', function(hooks) {
   setupRenderingTest(hooks);
@@ -16,42 +21,64 @@ module('Integration | Helper | prevent-default', function(hooks) {
     };
   });
 
+  testIfEventHelpersInstalled(
+    'prevent-default is stripped from the build',
+    function(assert) {
+      assert.notOk(
+        require.has('ember-on-modifier/helpers/prevent-default'),
+        'ember-on-modifier `prevent-default` is stripped'
+      );
+      assert.ok(
+        this.owner.lookup('helper:prevent-default').isHelperFactory,
+        '`prevent-default` from ember-event-helpers is present'
+      );
+    }
+  );
+
   // The rest of this test suite relies on this.
-  test('a submit button works in tests and submits the form', async function(assert) {
-    assert.expect(1);
+  skipIfEventHelpersInstalled(
+    'a submit button works in tests and submits the form',
+    async function(assert) {
+      assert.expect(1);
 
-    this.onSubmit = event => {
-      event.preventDefault();
-      assert.ok(true);
-    };
+      this.onSubmit = event => {
+        event.preventDefault();
+        assert.ok(true);
+      };
 
-    await render(hbs`
+      await render(hbs`
       <form {{on "submit" this.onSubmit}}>
         <button type="submit">Click me</button>
       </form>
     `);
 
-    await click('button');
-  });
+      await click('button');
+    }
+  );
 
-  test('{{on "click" (prevent-default)}}', async function(assert) {
-    assert.expect(0);
+  skipIfEventHelpersInstalled(
+    '{{on "click" (prevent-default)}}',
+    async function(assert) {
+      assert.expect(0);
 
-    await render(hbs`
+      await render(hbs`
       <form {{on "submit" this.onSubmit}}>
         <button type="submit" {{on "click" (prevent-default)}}>Click me</button>
       </form>
     `);
 
-    await click('button');
-  });
+      await click('button');
+    }
+  );
 
-  test('{{on "click" this.onClick}} {{on "click" (prevent-default)}}', async function(assert) {
-    assert.expect(1);
+  skipIfEventHelpersInstalled(
+    '{{on "click" this.onClick}} {{on "click" (prevent-default)}}',
+    async function(assert) {
+      assert.expect(1);
 
-    this.onClick = event => assert.ok(event instanceof Event);
+      this.onClick = event => assert.ok(event instanceof Event);
 
-    await render(hbs`
+      await render(hbs`
       <form {{on "submit" this.onSubmit}}>
         <button
           type="submit"
@@ -63,15 +90,18 @@ module('Integration | Helper | prevent-default', function(hooks) {
       </form>
     `);
 
-    await click('button');
-  });
+      await click('button');
+    }
+  );
 
-  test('{{on "click" (prevent-default)}} {{on "click" this.onClick}}', async function(assert) {
-    assert.expect(1);
+  skipIfEventHelpersInstalled(
+    '{{on "click" (prevent-default)}} {{on "click" this.onClick}}',
+    async function(assert) {
+      assert.expect(1);
 
-    this.onClick = event => assert.ok(event instanceof Event);
+      this.onClick = event => assert.ok(event instanceof Event);
 
-    await render(hbs`
+      await render(hbs`
       <form {{on "submit" this.onSubmit}}>
         <button
           type="submit"
@@ -83,15 +113,18 @@ module('Integration | Helper | prevent-default', function(hooks) {
       </form>
     `);
 
-    await click('button');
-  });
+      await click('button');
+    }
+  );
 
-  test('{{on "click" (prevent-default this.onClick)}}', async function(assert) {
-    assert.expect(1);
+  skipIfEventHelpersInstalled(
+    '{{on "click" (prevent-default this.onClick)}}',
+    async function(assert) {
+      assert.expect(1);
 
-    this.onClick = event => assert.ok(event instanceof Event);
+      this.onClick = event => assert.ok(event instanceof Event);
 
-    await render(hbs`
+      await render(hbs`
       <form {{on "submit" this.onSubmit}}>
         <button
           type="submit"
@@ -102,6 +135,7 @@ module('Integration | Helper | prevent-default', function(hooks) {
       </form>
     `);
 
-    await click('button');
-  });
+      await click('button');
+    }
+  );
 });

--- a/tests/unit/helpers/prevent-default-test.js
+++ b/tests/unit/helpers/prevent-default-test.js
@@ -1,49 +1,60 @@
-import { preventDefault } from 'ember-on-modifier/helpers/prevent-default';
-import { module, test } from 'qunit';
+import { module } from 'qunit';
+import require from 'require';
+import { skipIfEventHelpersInstalled } from '../../helpers/ember-event-helpers';
 
-module('Unit | Helper | prevent-default', function() {
-  test('it throws an assertion, when used incorrectly', function(assert) {
-    assert.expectAssertion(() => {
-      preventDefault(['not a function']);
-    }, `Expected 'not a function' to be a function, if present.`);
-
-    assert.expectAssertion(() => {
-      preventDefault([])('not an event');
-    }, `Expected 'not an event' to be an Event and have a 'preventDefault' method.`);
-
-    assert.expectAssertion(() => {
-      preventDefault([])({ preventDefault: 'not a method' });
-    }, `Expected '[object Object]' to be an Event and have a 'preventDefault' method.`);
+module('Unit | Helper | prevent-default', function(hooks) {
+  hooks.before(function() {
+    this.preventDefault = require('ember-on-modifier/helpers/prevent-default').preventDefault;
   });
 
-  test('it works without a handler', function(assert) {
+  skipIfEventHelpersInstalled(
+    'it throws an assertion, when used incorrectly',
+    function(assert) {
+      assert.expectAssertion(() => {
+        this.preventDefault(['not a function']);
+      }, `Expected 'not a function' to be a function, if present.`);
+
+      assert.expectAssertion(() => {
+        this.preventDefault([])('not an event');
+      }, `Expected 'not an event' to be an Event and have a 'preventDefault' method.`);
+
+      assert.expectAssertion(() => {
+        this.preventDefault([])({ preventDefault: 'not a method' });
+      }, `Expected '[object Object]' to be an Event and have a 'preventDefault' method.`);
+    }
+  );
+
+  skipIfEventHelpersInstalled('it works without a handler', function(assert) {
     assert.expect(1);
-    preventDefault([])({
+    this.preventDefault([])({
       preventDefault: () => assert.ok(true, `it has called 'preventDefault'`)
     });
   });
 
-  test('it works with a handler', function(assert) {
+  skipIfEventHelpersInstalled('it works with a handler', function(assert) {
     assert.expect(2);
-    preventDefault([() => assert.ok(true, 'it has called the handler')])({
+    this.preventDefault([() => assert.ok(true, 'it has called the handler')])({
       preventDefault: () => assert.ok(true, `it has called 'preventDefault'`)
     });
   });
 
-  test(`it calls 'preventDefault', even if the handler throws`, function(assert) {
-    assert.expect(2);
-    assert.throws(
-      () =>
-        preventDefault([
-          () => {
-            throw new Error('foobar');
-          }
-        ])({
-          preventDefault: () =>
-            assert.ok(true, `it has called 'preventDefault'`)
-        }),
-      /foobar/,
-      'The error has bubbled up'
-    );
-  });
+  skipIfEventHelpersInstalled(
+    `it calls 'preventDefault', even if the handler throws`,
+    function(assert) {
+      assert.expect(2);
+      assert.throws(
+        () =>
+          this.preventDefault([
+            () => {
+              throw new Error('foobar');
+            }
+          ])({
+            preventDefault: () =>
+              assert.ok(true, `it has called 'preventDefault'`)
+          }),
+        /foobar/,
+        'The error has bubbled up'
+      );
+    }
+  );
 });


### PR DESCRIPTION
Closes #48.

Also strips `(prevent-default)`, if `ember-event-helpers` is installed.