### PR TITLE
test: [>=3.11] fix CI when the polyfill is inert

### DIFF
--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -3,16 +3,30 @@ import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 import QUnit from 'qunit';
-import { __counts } from 'ember-on-modifier/modifiers/on';
+import require, { has } from 'require';
+// import { __counts } from 'ember-on-modifier/modifiers/on';
+
+let __counts = null;
+
+if (has('ember-on-modifier/modifiers/on')) {
+  __counts = require('ember-on-modifier/modifiers/on').__counts;
+}
 
 QUnit.testStart(() => {
-  QUnit.config.current.testEnvironment._startingCounts = __counts();
+  if (__counts !== null) {
+    QUnit.config.current.testEnvironment._startingCounts = __counts();
+  }
 });
 
 QUnit.assert.counts = function(
   expected,
   message = `counters have incremented by ${JSON.stringify(expected)}`
 ) {
+  if (__counts === null) {
+    this.ok(true, 'using upstream implementation, not asserting on counts');
+    return;
+  }
+
   const current = __counts();
 
   this.deepEqual(


### PR DESCRIPTION
Currently, CI is failing for beta and canary scenarios because we are eagerly importing from `ember-on-modifier/modifiers/on` in `tests/test-helper.js`, but when ran against Ember >= 3.11 we emit no modules causing the import to fail.

This makes the import use `require` so that we can detect the Ember >= 3.11 case, and avoid erroring. The downside is that we can no longer make count based assertions, but those assertions already live upstream in Ember so it's not an issue.